### PR TITLE
Add git url to META file

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,4 +13,14 @@ WriteMakefile(
     'Text::Balanced' => '1.97',
     'Filter::Util::Call' => 0
   },
+  META_MERGE => {
+      'meta-spec' => { version => 2 },
+      resources => {
+          repository => {
+              type => 'git',
+              url => 'https://github.com/tsee/Filter-Simple.git',
+              web => 'https://github.com/tsee/Filter-Simple',
+          },
+      },
+  },
 );


### PR DESCRIPTION
This should make your repo easier to find from MetaCPAN or search.cpan.org.

If you would like to learn more about linking to a version control system, checkout [this article](http://perlmaven.com/how-to-add-link-to-version-control-system-of-a-cpan-distributions) by Gabor Szabo. I pulled the config for `ExtUtils::MakeMaker` from that article.
